### PR TITLE
feat(docs): augmentations & supplements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # xnd
 
-Safely extending and complementing JavaScript built-ins since 2021.
+Safely augmenting and supplementing JavaScript built-ins since 2021.
 
 See the [documentation](https://doc.deno.land/https://deno.land/x/xnd/_index.ts) to discover all that Xnd has to offer. Xnd is inspired by prior art such as the [Kotlin Standard Library](https://kotlinlang.org/api/latest/jvm/stdlib/#kotlin-standard-library), [Google Guava](https://guava.dev/), and many others.
 
 ## Usage
 
-Xnd is a collection of extensions and complements to JavaScript built-ins. Extensions and complements are defined in [JavaScript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) meaning that you can use them in [Deno](https://deno.land/), [Node.js](https://nodejs.org/), and on the web.
+Xnd is a collection of augmentations and supplements to JavaScript built-ins. Augmentations and supplements are defined in [JavaScript modules](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules) meaning that you can use them in [Deno](https://deno.land/), [Node.js](https://nodejs.org/), and on the web.
 
 ### Deno
 

--- a/_tools/build_node_package.ts
+++ b/_tools/build_node_package.ts
@@ -23,7 +23,7 @@ await build({
     name: "xnd",
     version: Deno.args[0]?.replace(/^v/, ""),
     description:
-      "Safely extending and complementing JavaScript built-ins since 2021.",
+      "Safely augmenting and supplementing JavaScript built-ins since 2021.",
     license: "MIT",
     repository: {
       type: "git",


### PR DESCRIPTION
drop "extensions" and "complements"

use "augmentations" and "supplements" instead

Closes #4